### PR TITLE
Dust limit: add man option

### DIFF
--- a/doc/man/dogecoin-qt.1
+++ b/doc/man/dogecoin-qt.1
@@ -52,6 +52,10 @@ Specify data directory
 .IP
 Set database cache size in megabytes (4 to 16384, default: 450)
 .HP
+\fB\-dustlimit=\fR<amt>
+.IP
+Amount of DOGE under which a transaction output is considered dust, in Koinu (default:100'000'000)
+.HP
 \fB\-loadblock=\fR<file>
 .IP
 Imports blocks from external blk000??.dat file on startup

--- a/doc/man/dogecoind.1
+++ b/doc/man/dogecoind.1
@@ -57,6 +57,10 @@ Specify data directory
 .IP
 Set database cache size in megabytes (4 to 16384, default: 450)
 .HP
+\fB\-dustlimit=\fR<amt>
+.IP
+Amount of DOGE under which a transaction output is considered dust, in Koinu (default:100'000'000)
+.HP
 \fB\-loadblock=\fR<file>
 .IP
 Imports blocks from external blk000??.dat file on startup


### PR DESCRIPTION
I added the option to `dogecoind` and `dogecoin-qt` man.

Actually, in the help message, you're using the `-dustlimit` syntax, but I believe it takes a value, so I used `-dustlimit=<amt>` instead.  
Something to change in your or in mine code.